### PR TITLE
Health and damage refactor

### DIFF
--- a/scripts/bullets/bullets.tscn
+++ b/scripts/bullets/bullets.tscn
@@ -12,7 +12,7 @@ texture_filter = 1
 texture_repeat = 1
 script = ExtResource("2_c8q4u")
 post_collision = ExtResource("3_cgiwy")
-DAMAGE = 35
+damage = 20
 SPEED = 1000
 
 [node name="Texture" type="Sprite2D" parent="."]

--- a/scripts/bullets/bullets_physics_handler.gd
+++ b/scripts/bullets/bullets_physics_handler.gd
@@ -1,7 +1,7 @@
 class_name Bullet extends Sprite2D
 
 @export var post_collision: PackedScene
-@export var DAMAGE: int
+@export var damage: int
 @export_range(10.0, 2000.0, 1.0) var SPEED: int
 @export var LIFETIME: float = 2
 
@@ -26,9 +26,14 @@ func _physics_process(delta):
 	query.position = global_position
 	var results: Array = get_world_2d().direct_space_state.intersect_point(query, 1)
 	for result in results:
-		var entity = result["collider"]
-		if entity.has_method("hit"):
-			entity.hit(global_position, DAMAGE)
+		var collider :Node = result["collider"]
+		var health := collider.get_node_or_null("%HealthComponent") as HealthComponent
+		if health != null:
+			var change := HealthComponent.new_package()
+			change.damage = damage
+			health.apply(change)
+		if collider.has_signal("hit"):
+			collider.emit_signal("hit", self)
 		explode()
 
 func _pool_claim():

--- a/scripts/components/health_bar_component.gd
+++ b/scripts/components/health_bar_component.gd
@@ -5,7 +5,7 @@ var entity:Node:
 var health:HealthComponent:
 	get: return entity.get_node("%HealthComponent")
 var progress:TextureProgressBar:
-	get: return $ProgressBar
+	get: return %ProgressBar
 
 func _ready() -> void:
 	health.changed.connect(_on_change)

--- a/scripts/components/health_bar_component.gd
+++ b/scripts/components/health_bar_component.gd
@@ -1,0 +1,21 @@
+extends Node2D
+
+var entity:Node:
+	get: return owner
+var health:HealthComponent:
+	get: return entity.get_node("%HealthComponent")
+var progress:TextureProgressBar:
+	get: return $ProgressBar
+
+func _ready() -> void:
+	health.changed.connect(_on_change)
+	update()
+
+func update():
+	progress.max_value = health.max_value
+	progress.value = health.value
+	if health.is_dead:
+		hide()
+
+func _on_change(change:HealthComponent.Result):
+	update()

--- a/scripts/components/health_bar_component.tscn
+++ b/scripts/components/health_bar_component.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=3 uid="uid://bkcdlvpolk3kf"]
+
+[ext_resource type="Texture2D" uid="uid://d0565egri1gj" path="res://resources/ui/health.png" id="1_3u5qt"]
+[ext_resource type="Script" path="res://scripts/components/health_bar_component.gd" id="1_v0uxh"]
+
+[node name="HealthBarComponent" type="Node2D"]
+position = Vector2(0, -32)
+scale = Vector2(0.485, 0.12)
+script = ExtResource("1_v0uxh")
+
+[node name="ProgressBar" type="TextureProgressBar" parent="."]
+unique_name_in_owner = true
+offset_left = -57.732
+offset_top = -25.0
+offset_right = 326.268
+offset_bottom = -2.0
+scale = Vector2(0.3, 2)
+value = 100.0
+texture_progress = ExtResource("1_3u5qt")

--- a/scripts/components/health_component.gd
+++ b/scripts/components/health_component.gd
@@ -1,10 +1,64 @@
 class_name HealthComponent extends Node2D
 
-@export var health: int = 100
-@export var health_increment: int = 1
+@export var max_value :int = 100
+@export var value :int = 100:
+	set(v): value = clampi(v, 0, max_value)
+var percent:float:
+	get: return float(value)/max_value
+	set(v): value = ceili(max_value*v)
+var is_dead :bool = false
+
+signal changed(res:Result)
+signal died()
+
+static func new_package() -> ChangePackage:
+	return ChangePackage.new()
+
+func get_info_string()->String:
+	return "%d/%d"%[value, max_value]
+
+func apply(change:ChangePackage)-> Result:
+	var res = Result.new()
+	res.change_package = change
+	if is_dead:
+		#changed.emit(res)
+		return res
+	
+	var old := value
+	value += change.amount
+	
+	res.actual_amount = value - old
+	if change.damage > 0 and value == 0:
+		res.killed = true
+		is_dead = true
+	
+	changed.emit(res)
+	if res.killed:
+		died.emit()
+	return res
 
 func _write_data(data:Dictionary):
-	data.health = health
+	data.health = value
 
 func _read_data(data:Dictionary):
-	health = data.health
+	value = data.health
+
+class ChangePackage:
+	# you can put here some more data for different systems
+	# for example you might want this
+	# if you want to return damage back to the attacker or count kills per entity:
+	# var source_entity :Node
+	# or if you want damage types and resistances:
+	# var type :DAMAGE_TYPE
+	var amount :int = 0
+	var damage:
+		get: return maxi(0, -amount)
+		set(val): amount = -maxi(0, val)
+	var healing:
+		get: return maxi(0, amount)
+		set(val): amount = maxi(0, val)
+
+class Result:
+	var actual_amount :int = 0
+	var killed :bool = false
+	var change_package :ChangePackage

--- a/scripts/components/hit_effects.gd
+++ b/scripts/components/hit_effects.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+@export var knockback_factor: float = 10
+@export var modulation := Color(5.0, 5.0, 5.0)
+
+var entity :PhysicsBody2D:
+	get: return owner
+
+func _ready() -> void:
+	%HitboxComponent.connect("hit", _hit)
+
+func _hit(source_node:Node2D):
+	var dir := source_node.global_position.direction_to( entity.global_position )
+	knockback(dir)
+	hit_animation()
+
+func knockback(dir: Vector2):
+	var knockback_direction = sign(dir.x)
+
+	var knockback_transf := Vector2(knockback_direction * knockback_factor, -abs(knockback_factor/2))
+	entity.move_and_collide(knockback_transf)
+
+func hit_animation():
+	entity.modulate = modulation

--- a/scripts/components/hitbox_component.gd
+++ b/scripts/components/hitbox_component.gd
@@ -1,46 +1,4 @@
 extends Area2D
 
-@export var knockback_factor: float
-@export var health_component: HealthComponent
-
-func hit(bullet_position:Vector2, damage:int):
-	damaged(damage)
-	knockback(bullet_position)
-	hit_animation()
-
-func damaged(damage: int):
-	health_component.health -= damage
-	if health_component.health <= 0 and get_parent().has_method("dead"):
-		get_parent().modulate = Color(1.0, 1.0, 1.0)
-		get_parent().dead()
-		call_deferred("queue_free")
-
-func knockback(bullet_position: Vector2):
-
-	var knockback_transf:Vector2 = get_parent().global_position - bullet_position
-	var knockback_direction = sign(knockback_transf.x)
-
-	knockback_transf = Vector2(knockback_direction * knockback_factor, -abs(knockback_factor/2))
-
-	match EntityManager.get_entity_type(owner):
-		EntityManager.TYPE.PLAYER:
-			pass
-		EntityManager.TYPE.ENEMY:
-			get_parent().move_and_collide(knockback_transf)
-		EntityManager.TYPE.BOSS:
-			pass
-		EntityManager.TYPE.ENTITY:
-			pass
-
-func hit_animation():
-
-	match EntityManager.get_entity_type(owner):
-		EntityManager.TYPE.PLAYER:
-			pass
-		EntityManager.TYPE.ENEMY:
-			get_parent().modulate = Color(5.0, 5.0, 5.0)
-		EntityManager.TYPE.BOSS:
-			pass
-		EntityManager.TYPE.ENTITY:
-			pass
+signal hit(source_node:Node2D)
 

--- a/scripts/enemies/test/enemy_test.gd
+++ b/scripts/enemies/test/enemy_test.gd
@@ -1,6 +1,5 @@
 class_name Enemy extends RigidBody2D
 
-@onready var health_bar:TextureProgressBar = $Control/ControlHealthBar/HealthBar
 @onready var sprite:AnimatedSprite2D = $Sprite
 @onready var collider:CollisionShape2D = $Collision
 var camera_shaker := CameraShaker.new()
@@ -13,10 +12,7 @@ var health:HealthComponent:
 
 func _ready():
 	sprite.visible = true
-	health.changed.connect(_health_changed)
 	health.died.connect(_died)
-	health_bar.max_value = health.max_value
-	health_bar.value = health.value
 
 
 
@@ -43,16 +39,10 @@ func enemy_behaviour(delta):
 		$Sprite.flip_h = true
 	else:
 		$Sprite.flip_h = false
-	
-
-func _health_changed(res:HealthComponent.Result):
-	health_bar.max_value = health.max_value
-	health_bar.value = health.value
 
 func _died():
 	EntityManager.mark_as_unsaveable(self)
 	modulate = Color(1,1,1)
-	health_bar.visible = false
 	$AnimationPlayer.play("dead")
 	set_physics_process(false)
 	freeze = true

--- a/scripts/enemies/test/enemy_test.gd
+++ b/scripts/enemies/test/enemy_test.gd
@@ -1,17 +1,24 @@
 class_name Enemy extends RigidBody2D
 
-@export var health_component: HealthComponent
 @onready var health_bar:TextureProgressBar = $Control/ControlHealthBar/HealthBar
 @onready var sprite:AnimatedSprite2D = $Sprite
 @onready var collider:CollisionShape2D = $Collision
 var camera_shaker := CameraShaker.new()
-var is_dead: bool = false
 const SPEED = 5000
 const JUMP = -500
 var delta_player_position: Vector2
 
+var health:HealthComponent:
+	get: return %HealthComponent
+
 func _ready():
 	sprite.visible = true
+	health.changed.connect(_health_changed)
+	health.died.connect(_died)
+	health_bar.max_value = health.max_value
+	health_bar.value = health.value
+
+
 
 func _physics_process(delta):
 
@@ -36,21 +43,27 @@ func enemy_behaviour(delta):
 		$Sprite.flip_h = true
 	else:
 		$Sprite.flip_h = false
+	
 
-	health_bar.value = health_component.health
+func _health_changed(res:HealthComponent.Result):
+	health_bar.max_value = health.max_value
+	health_bar.value = health.value
 
-func dead():
-	if !is_dead:
-		health_bar.visible = false
-		$AnimationPlayer.play("dead")
-		set_physics_process(false)
-		freeze = true
-		sprite.visible = false
-		$Dead.start()
-		$Blood.emitting = true
-		collider.disabled = true
-		camera_shaker.shake_medium_medium()
-		is_dead = true
+func _died():
+	EntityManager.mark_as_unsaveable(self)
+	modulate = Color(1,1,1)
+	health_bar.visible = false
+	$AnimationPlayer.play("dead")
+	set_physics_process(false)
+	freeze = true
+	sprite.visible = false
+	$Dead.start()
+	$Blood.emitting = true
+	collider.disabled = true
+	camera_shaker.shake_medium_medium()
 
 func _on_animation_player_animation_finished(_anim_name):
+	queue_free()
+
+func _on_dead_timeout():
 	queue_free()

--- a/scripts/enemies/test/enemy_test.tscn
+++ b/scripts/enemies/test/enemy_test.tscn
@@ -1,15 +1,12 @@
 [gd_scene load_steps=25 format=3 uid="uid://dtqqr1dlyi2j"]
 
 [ext_resource type="Script" path="res://scripts/enemies/test/enemy_test.gd" id="1_qnvvi"]
-[ext_resource type="Texture2D" uid="uid://d0565egri1gj" path="res://resources/ui/health.png" id="2_6dffn"]
+[ext_resource type="PackedScene" uid="uid://bkcdlvpolk3kf" path="res://scripts/components/health_bar_component.tscn" id="2_fxvmp"]
 [ext_resource type="Texture2D" uid="uid://bbrcv4t864w8y" path="res://resources/sprites/entities/enemies/external/Robotic Drone Sprite Sheet.png" id="2_tjrwk"]
 [ext_resource type="PackedScene" uid="uid://64t337w2n4fs" path="res://scripts/components/hitbox_component.tscn" id="2_x4e1a"]
 [ext_resource type="PackedScene" uid="uid://cgsn8y8emb4lv" path="res://scripts/components/health_component.tscn" id="3_oly57"]
 [ext_resource type="Script" path="res://scripts/components/hit_effects.gd" id="4_ctbdh"]
 [ext_resource type="Texture2D" uid="uid://dv5vsmjuxg1lm" path="res://resources/circle2.png" id="7_nvdb6"]
-
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_4srq0"]
-size = Vector2(42.8571, 42.8571)
 
 [sub_resource type="Animation" id="Animation_78kes"]
 length = 0.001
@@ -98,6 +95,9 @@ _data = {
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_pwt7m"]
 size = Vector2(32, 32)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_4srq0"]
+size = Vector2(42.8571, 42.8571)
 
 [sub_resource type="Gradient" id="Gradient_8idty"]
 offsets = PackedFloat32Array(0, 0.705179, 0.992032, 1)
@@ -194,21 +194,6 @@ collision_layer = 0
 collision_mask = 3
 script = ExtResource("1_qnvvi")
 
-[node name="HitboxComponent" parent="." instance=ExtResource("2_x4e1a")]
-unique_name_in_owner = true
-collision_layer = 16
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="HitboxComponent"]
-shape = SubResource("RectangleShape2D_4srq0")
-debug_color = Color(0.956863, 0, 0.545098, 0.419608)
-
-[node name="HealthComponent" parent="." instance=ExtResource("3_oly57")]
-unique_name_in_owner = true
-
-[node name="HitEffects" type="Node2D" parent="."]
-unique_name_in_owner = true
-script = ExtResource("4_ctbdh")
-
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {
 "": SubResource("AnimationLibrary_lym4w")
@@ -220,20 +205,24 @@ shape = SubResource("RectangleShape2D_pwt7m")
 [node name="Icon" type="Sprite2D" parent="."]
 scale = Vector2(0.25, 0.25)
 
-[node name="Control" type="Node2D" parent="."]
+[node name="Components" type="Node2D" parent="."]
 
-[node name="ControlHealthBar" type="Node2D" parent="Control"]
-position = Vector2(0, -32)
-scale = Vector2(0.485, 0.12)
+[node name="HealthBarComponent" parent="Components" instance=ExtResource("2_fxvmp")]
 
-[node name="HealthBar" type="TextureProgressBar" parent="Control/ControlHealthBar"]
-offset_left = -57.732
-offset_top = -25.0
-offset_right = 326.268
-offset_bottom = -2.0
-scale = Vector2(0.3, 2)
-value = 100.0
-texture_progress = ExtResource("2_6dffn")
+[node name="HitboxComponent" parent="Components" instance=ExtResource("2_x4e1a")]
+unique_name_in_owner = true
+collision_layer = 16
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Components/HitboxComponent"]
+shape = SubResource("RectangleShape2D_4srq0")
+debug_color = Color(0.956863, 0, 0.545098, 0.419608)
+
+[node name="HealthComponent" parent="Components" instance=ExtResource("3_oly57")]
+unique_name_in_owner = true
+
+[node name="HitEffects" type="Node2D" parent="Components"]
+unique_name_in_owner = true
+script = ExtResource("4_ctbdh")
 
 [node name="Blood" type="GPUParticles2D" parent="."]
 rotation = 3.14159

--- a/scripts/enemies/test/enemy_test.tscn
+++ b/scripts/enemies/test/enemy_test.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=24 format=3 uid="uid://dtqqr1dlyi2j"]
+[gd_scene load_steps=25 format=3 uid="uid://dtqqr1dlyi2j"]
 
 [ext_resource type="Script" path="res://scripts/enemies/test/enemy_test.gd" id="1_qnvvi"]
 [ext_resource type="Texture2D" uid="uid://d0565egri1gj" path="res://resources/ui/health.png" id="2_6dffn"]
 [ext_resource type="Texture2D" uid="uid://bbrcv4t864w8y" path="res://resources/sprites/entities/enemies/external/Robotic Drone Sprite Sheet.png" id="2_tjrwk"]
 [ext_resource type="PackedScene" uid="uid://64t337w2n4fs" path="res://scripts/components/hitbox_component.tscn" id="2_x4e1a"]
 [ext_resource type="PackedScene" uid="uid://cgsn8y8emb4lv" path="res://scripts/components/health_component.tscn" id="3_oly57"]
+[ext_resource type="Script" path="res://scripts/components/hit_effects.gd" id="4_ctbdh"]
 [ext_resource type="Texture2D" uid="uid://dv5vsmjuxg1lm" path="res://resources/circle2.png" id="7_nvdb6"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4srq0"]
@@ -187,23 +188,26 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="EnemyTest" type="RigidBody2D" node_paths=PackedStringArray("health_component")]
+[node name="EnemyTest" type="RigidBody2D"]
 scale = Vector2(0.07, 0.07)
 collision_layer = 0
 collision_mask = 3
 script = ExtResource("1_qnvvi")
-health_component = NodePath("HealthComponent")
 
-[node name="HitboxComponent" parent="." node_paths=PackedStringArray("health_component") instance=ExtResource("2_x4e1a")]
+[node name="HitboxComponent" parent="." instance=ExtResource("2_x4e1a")]
+unique_name_in_owner = true
 collision_layer = 16
-knockback_factor = 10.0
-health_component = NodePath("../HealthComponent")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitboxComponent"]
 shape = SubResource("RectangleShape2D_4srq0")
 debug_color = Color(0.956863, 0, 0.545098, 0.419608)
 
 [node name="HealthComponent" parent="." instance=ExtResource("3_oly57")]
+unique_name_in_owner = true
+
+[node name="HitEffects" type="Node2D" parent="."]
+unique_name_in_owner = true
+script = ExtResource("4_ctbdh")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/scripts/global/entity_manager.gd
+++ b/scripts/global/entity_manager.gd
@@ -39,6 +39,12 @@ func get_type_group(type:TYPE) -> String:
 func get_sub_type_group(type:TYPE, sub_type:String) -> String:
 	return get_type_name(type)+"_"+sub_type
 
+func mark_as_unsaveable(entity:Node):
+	entity.set_meta("unsaveable_entity", true)
+
+func is_unsaveable(entity:Node) -> bool:
+	return entity.has_meta("unsaveable_entity")
+
 func new_entity(type:TYPE, sub_type:String) -> Node:
 	var scene :PackedScene = sub_types[type][sub_type]
 	var entity :Node = scene.instantiate()
@@ -53,6 +59,8 @@ func new_entity(type:TYPE, sub_type:String) -> Node:
 func _write_data(common_data:Dictionary):
 	var list := []
 	for entity:Node in get_tree().get_nodes_in_group(EntityManager.BASE_GROUP):
+		if is_unsaveable(entity):
+			continue
 		var data := {
 			id = entity.get_instance_id(),
 			type = EntityManager.get_entity_type(entity),

--- a/scripts/player/player.tscn
+++ b/scripts/player/player.tscn
@@ -159,7 +159,6 @@ debug_color = Color(0.460277, 0.544393, 0.645848, 0.42)
 
 [node name="HealthComponent" parent="Components" instance=ExtResource("2_8tngo")]
 unique_name_in_owner = true
-health = 1000
 
 [node name="HitboxComponent" parent="Components" instance=ExtResource("4_kgvqi")]
 unique_name_in_owner = true


### PR DESCRIPTION
This health system can easily be extended to support more complex features, like damage types with resistances.

I separated knockback from health completely, because there might be situations where hits are not related to health at all. For example buttons that you shoot or boxes that you push by shooting them.

Regarding hit modulation, it might be a good idea to use AnimationPlayer for that (or AnimationTree, if you want fancy blending).
Perhaps all visuals should be done through animations, including death particles, though i am not sure, i haven't actually used animations much.

Also, i found a slight quirk of %unique names: it works for root node as long as it has no unique nodes of it's own.
For example, when i added a unique node to HealthBarComponent, `%HealthComponent` stopped working in it. Instead, i had to use `owner.get_node("%HealthComponent")`.
You might have to make similar change to other components if they get unique nodes of their own.